### PR TITLE
优化打包速度

### DIFF
--- a/Assets/Engine/Editor/MePackager.cs
+++ b/Assets/Engine/Editor/MePackager.cs
@@ -250,7 +250,7 @@ public class MePackager
             File.WriteAllBytes(targetFullFilePath, fileBytes);
         }
 
-        Debug.Log(targetPath + " 文件夹已复制到 " + targetPath);
+        Debug.Log(srcPath + " 文件夹已复制到 " + targetPath);
     }
 
 

--- a/Assets/Engine/Editor/MePackager.cs
+++ b/Assets/Engine/Editor/MePackager.cs
@@ -229,7 +229,7 @@ public class MePackager
          */ 
     }
 
-    [MenuItem("ME Tools/4.同步代码到缓存 : 直接复制Asset->Lua目录(内含所有lua脚本文件)到缓存")]
+    [MenuItem("ME Tools/5.同步代码到缓存 : 直接复制Asset->Lua目录(内含所有lua脚本文件)到缓存")]
     public static void copyToCache()
     {
         string targetPath = API.AssetRoot + "lua";

--- a/Assets/Engine/Editor/MePackager.cs
+++ b/Assets/Engine/Editor/MePackager.cs
@@ -13,18 +13,38 @@ public class MePackager
 
     [MenuItem("ME Tools/1.清理缓存,让一切重新开始")]
     public static void CleanCacheFiles()
-    {
+    {     
         string cachePath = API.AssetRoot;
         DirectoryInfo di = new DirectoryInfo(cachePath);
         di.Delete(true);
 
-        Debug.Log("缓存目录:" + cachePath + " 已经删除!");
+        Debug.LogWarning("缓存目录:" + cachePath + " 已经删除!");
     }
 
-    [MenuItem("ME Tools/2.制作资源包 : 自动生成资源包并放入Asset->Data->asset目录 (for Unity5.0+)")]
-    public static void BuildAssets()
-    {
+    [MenuItem("ME Tools/2.清理旧资源包 : 清除Builds->AssetBundles,Data->asset目录,建议仅在有删除资源时使用 (for Unity5.0+)")]
+    public static void ClearAssets()
+    {   
+        //清空
+        string mPath = Application.dataPath + "/Builds/AssetBundles/";
+        DirectoryInfo mDirInfo = new DirectoryInfo(mPath);
+        if (mDirInfo.Exists)
+        {
+            mDirInfo.Delete(true);
+        }
+        Debug.LogWarning("已清除" + mPath);
 
+        string toPath = Application.dataPath + "/Data/asset/";
+        DirectoryInfo toDirInfo = new DirectoryInfo(toPath);
+        if (toDirInfo.Exists)
+        {            
+            toDirInfo.Delete(true);
+        }
+        Debug.LogWarning("已清除" + Application.dataPath + "/Data/asset/");
+    }
+
+    [MenuItem("ME Tools/3.制作新资源包 : 生成新的资源包并放入Data->asset目录 (for Unity5.0+)")]
+    public static void BuildAssets()
+    {       
         //复制lua
         EncryptLua();
 
@@ -32,35 +52,38 @@ public class MePackager
         string mPath = Application.dataPath + "/Builds/AssetBundles/";
         string toPath = Application.dataPath + "/Data/asset/" + target.ToString().ToLower() + "/";
 
-        //清空
-        DirectoryInfo toDirInfo = new DirectoryInfo(Application.dataPath + "/Data/asset/");
-        if (toDirInfo.Exists)
+        
+        if (!Directory.Exists(toPath))
         {
-            toDirInfo.Delete(true);
+            Debug.Log("创建" + toPath);
+            Directory.CreateDirectory(toPath);
         }
-        if (!Directory.Exists(toPath)) Directory.CreateDirectory(toPath);
+        
 
+        if (!Directory.Exists(mPath))
+        {
+            Debug.Log("创建" + mPath);
+            Directory.CreateDirectory(mPath);
+        }
         DirectoryInfo mDirInfo = new DirectoryInfo(mPath);
-        if (mDirInfo.Exists)
-        {
-            mDirInfo.Delete(true);
-        }
 
-        if (!Directory.Exists(mPath)) Directory.CreateDirectory(mPath);
-       
-        BuildPipeline.BuildAssetBundles(mPath, 0, target);
+        Debug.Log("打包资源到" + mPath+"目录");
+        BuildPipeline.BuildAssetBundles(mPath,BuildAssetBundleOptions.None, target);
 
-        //复制资源
+        Debug.Log("AssetBundle打包完成！");
+
+        //复制资源        
         foreach (FileInfo mFile in mDirInfo.GetFiles(assetbundle_extension, SearchOption.AllDirectories))
         {
             string from = mFile.FullName;
-            string to = from.Replace("\\", "/");
+            string to = from.Replace("\\", "/");           
             to = to.Replace(mPath, toPath);
             EncryptFile(from, to);
         }
+        Debug.Log("新资源文件已复制到" + toPath);
     }
     
-    [MenuItem("ME Tools/3.制作更新包 : 把Asset->Data目录压缩为一个zip包并放入StreamingAssets目录")]
+    [MenuItem("ME Tools/4.制作ZIP更新包 : 把Data目录压缩为一个zip包并放入StreamingAssets目录")]
     public static void PackFiles()
     {
         //本地测试：建议最后将Assetbundle放在StreamingAssets文件夹下，如果没有就创建一个，因为移动平台下只能读取这个路径
@@ -118,10 +141,10 @@ public class MePackager
         //删除临时文件
         if (!form.Equals(to))
         {
-            File.Delete(form);
+            //File.Delete(form);  //不要删除Builds/AssetBundles下的ab文件，这样unity5.0新的打包机制可以发挥作用，对没有变化的ab资源不会重复打包，大大加快打包速度
         }
 
-        Debug.Log(to + " ==>ok!!");
+        //Debug.Log(to + " ==>ok!!");
     }
 
     public static void EncryptLua()
@@ -132,10 +155,14 @@ public class MePackager
 
         DirectoryInfo srcDirInfo = new DirectoryInfo(srcPath);
         DirectoryInfo toDirInfo = new DirectoryInfo(toPath);
-
+        
         if (toDirInfo.Exists)
         {
+            Debug.LogWarning("删除" + toPath);
             toDirInfo.Delete(true);
+
+            Debug.LogWarning("创建" + toPath);
+            Directory.CreateDirectory(toPath);
         }
 
         //复制
@@ -147,8 +174,18 @@ public class MePackager
             to = to.Replace(srcPath, toPath);
 
             string path = Path.GetDirectoryName(to);
-            if (!Directory.Exists(path)) Directory.CreateDirectory(path);
+            if (!Directory.Exists(path))
+            {
+                //Debug.LogWarning("创建" + path);
+                Directory.CreateDirectory(path);
+            }
             File.Copy(form, to, true);
+            FileInfo fi = new FileInfo(to);
+         
+            if (fi.Attributes.ToString().IndexOf("ReadOnly") != -1) 
+            {
+                fi.Attributes = FileAttributes.Normal; //去除只读属性
+            }          
         }
 
         //以下是进行lua脚本的加密,（加密:windows版l已OK（luac批处理）,ios的请高手提交代码; 解密:待完善,即让lua requrie函数使用c#函数来执行解密）
@@ -157,17 +194,22 @@ public class MePackager
          runLuac();
 
         */
+
+        /*
           //rc4 
         foreach (FileInfo luaFile in toDirInfo.GetFiles("*.lua", SearchOption.AllDirectories))
          {
              string allPath = luaFile.FullName;
+             Debug.LogWarning("加密" + allPath);
              EncryptFile(allPath, allPath); //进行RC4
-         }   
+         }
+         */ 
     }
 
     //luac for windows
     static void runLuac()
     {
+        /*
 #if UNITY_EDITOR_WIN
         string runPath = Application.dataPath + "/Engine/Tools/run.bat";
         string luacPath = Application.dataPath+"/Engine/Tools/luac.exe";
@@ -184,6 +226,7 @@ public class MePackager
         p.Dispose();
         p.Close();
 #endif
+         */ 
     }
 
     [MenuItem("ME Tools/4.同步代码到缓存 : 直接复制Asset->Lua目录(内含所有lua脚本文件)到缓存")]


### PR DESCRIPTION
1.分离清除旧包资源和打新包操作，让unity5.0的智能判断资源变化机制发挥作用，只打有变化的资源包，加速打包速度。
